### PR TITLE
Update license-switch.yml

### DIFF
--- a/.github/workflows/license-switch.yml
+++ b/.github/workflows/license-switch.yml
@@ -23,38 +23,38 @@ jobs:
           echo "today=$TODAY" >> "$GITHUB_OUTPUT"
 
       - name: Stop if before change date
-        if: steps.date.outputs.today < '2035-01-01'
-        run: echo "Not yet 2035-01-01, skipping."
+        if: steps.date.outputs.today < '2025-12-22'
+        run: echo "Not yet 2025-12-22, skipping."
 
       - name: Backup current LICENSE
-        if: steps.date.outputs.today >= '2035-01-01'
+        if: steps.date.outputs.today >= '2025-12-22'
         run: |
           mkdir -p .github/LICENSES
           cp LICENSE .github/LICENSES/old-LICENSE
 
       - name: Switch LICENSE to Apache-2.0
-        if: steps.date.outputs.today >= '2035-01-01'
+        if: steps.date.outputs.today >= '2025-12-22'
         run: |
           test -f .github/LICENSES/LICENSE-Apache2.0.txt
           cp .github/LICENSES/LICENSE-Apache2.0.txt LICENSE
 
       - name: Remove this workflow after switch
-        if: steps.date.outputs.today >= '2035-01-01'
+        if: steps.date.outputs.today >= '2025-12-22'
         run: |
           rm -f .github/workflows/license-switch.yml
 
-      - name: Create Pull Request
-        if: steps.date.outputs.today >= '2035-01-01'
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: license-switch/apache-2.0
-          delete-branch: true
-          commit-message: "chore(license): switch to Apache-2.0 per BSL change date"
-          title: "Switch license to Apache-2.0"
-          body: |
-            This PR switches the project license to Apache-2.0
-            in accordance with the Business Source License 1.1 Change Date (2035-01-01).
-
-            The previous BSL license has been archived at:
-            .github/LICENSES/old-LICENSE
-          labels: license
+      - name: Commit and push changes
+        if: steps.date.outputs.today >= '2025-12-22'
+        env:
+          BRANCH_NAME: license-switch/apache-2.0
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH_NAME"
+          if git diff --quiet; then
+            echo "No changes to commit; exiting."
+            exit 0
+          fi
+          git add -A
+          git commit -m "chore(license): switch to Apache-2.0 per BSL change date"
+          git push --force origin "$BRANCH_NAME"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Move license switch date to 2025-12-22 and replace PR creation with direct commit/push to branch.
> 
> - **CI · GitHub Actions** (`.github/workflows/license-switch.yml`):
>   - Change license change date gate from `2035-01-01` to `2025-12-22` across all conditional steps.
>   - Replace `peter-evans/create-pull-request` with a step that commits and force-pushes changes to `license-switch/apache-2.0`.
>   - Retain backup of `LICENSE`, switch to `Apache-2.0`, and self-removal of workflow, all gated by the new date.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9f6886cdf80926fced3774baa258992ab315b5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->